### PR TITLE
Add selectable base URLs and optional key

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Let users pick their OpenAI compatible API provider (e.g. OpenRouter, Ollama) vi
 To use locally, install via `npm`:
 
 ```bash
-npm install bootstrap-llm-provider@1
+npm install bootstrap-llm-provider@1.1
 ```
 
 ... and add this to your script:
@@ -24,23 +24,33 @@ import { openaiConfig } from "./node_modules/bootstrap-llm-provider/dist/bootstr
 To use via CDN, add this to your script:
 
 ```js
-import { openaiConfig } from "https://cdn.jsdelivr.net/npm/bootstrap-llm-provider@1";
+import { openaiConfig } from "https://cdn.jsdelivr.net/npm/bootstrap-llm-provider@1.1";
 ```
 
 ## Quick Start
 
 ```js
-import { openaiConfig } from "https://cdn.jsdelivr.net/npm/bootstrap-llm-provider@1";
+import { openaiConfig } from "https://cdn.jsdelivr.net/npm/bootstrap-llm-provider@1.1";
 
 // Basic Config - Opens a model and asks user for provider details
 const { baseURL, apiKey, models } = await openaiConfig();
 
+// API key is optional if your provider doesn't require one
+
 // Always Show Modal - even if user has provided information before
 const { baseURL, apiKey, models } = await openaiConfig({ show: true });
 
-// Custom Base URLs
+// Custom Base URLs (datalist)
 const { baseURL, apiKey, models } = await openaiConfig({
   defaultBaseUrls: ["https://api.openai.com/v1", "https://openrouter.com/api/v1"],
+});
+
+// Base URL Options (select)
+const { baseURL, apiKey, models } = await openaiConfig({
+  baseUrls: [
+    { url: "https://api.openai.com/v1", name: "OpenAI" },
+    { url: "https://openrouter.com/api/v1", name: "OpenRouter" },
+  ],
 });
 
 // Custom Storage - store in sessionStorage.llmProvider
@@ -64,7 +74,8 @@ async function openaiConfig({
   storage: localStorage,                          // where to store, e.g. sessionStorage
   key: "bootstrapLLMProvider_openaiConfig",       // key name for storage
   defaultBaseUrls: ["https://api.openai.com/v1"], // array of URL strings for user to pick from
-  show: false                                     // true will force prompt even if config exists
+  baseUrls: undefined,                            // array of { url, name } objects
+  show: false,                                    // true will force prompt even if config exists
   title: "OpenAI API Configuration",              // modal dialog title
   baseURLLabel: "API Base URL",                   // base URL label
   apiKeyLabel: "API Key",                         // api key label
@@ -74,12 +85,13 @@ async function openaiConfig({
 ```
 
 - If there's no valid config, or `show` is true, it displays a Bootstrap modal with:
-  - Base URL input, prefilled from storage or empty, with a datalist of `defaultBaseUrls`
-  - API key input, prefilled from storage if present
+  - Base URL input with datalist of `defaultBaseUrls`, or a select of `baseUrls`
+  - API key input, may be empty, prefilled from storage if present
   - On submit, it:
     1. Fetches `${baseURL}/models` using the API key
     2. On success, save `{ baseURL, apiKey }` to storage under `key`; return `{ baseURL, apiKey, models }`
     3. On failure, throws an Error
+  - `baseUrls` overrides `defaultBaseUrls` if both are provided
 - If config exists, it skips the prompt, fetches models and returns
 
 ## Development
@@ -95,6 +107,11 @@ npm run build
 npm test
 npm publish
 ```
+
+## Changelog
+
+- **1.1.0** - 2025-07-25 - optional API key and `baseUrls` select
+- **1.0.0** - 2025-07-20 - initial release
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -33,20 +33,20 @@ import { openaiConfig } from "https://cdn.jsdelivr.net/npm/bootstrap-llm-provide
 import { openaiConfig } from "https://cdn.jsdelivr.net/npm/bootstrap-llm-provider@1.1";
 
 // Basic Config - Opens a model and asks user for provider details
-const { baseURL, apiKey, models } = await openaiConfig();
+const { baseUrl, apiKey, models } = await openaiConfig();
 
 // API key is optional if your provider doesn't require one
 
 // Always Show Modal - even if user has provided information before
-const { baseURL, apiKey, models } = await openaiConfig({ show: true });
+const { baseUrl, apiKey, models } = await openaiConfig({ show: true });
 
 // Custom Base URLs (datalist)
-const { baseURL, apiKey, models } = await openaiConfig({
+const { baseUrl, apiKey, models } = await openaiConfig({
   defaultBaseUrls: ["https://api.openai.com/v1", "https://openrouter.com/api/v1"],
 });
 
 // Base URL Options (select)
-const { baseURL, apiKey, models } = await openaiConfig({
+const { baseUrl, apiKey, models } = await openaiConfig({
   baseUrls: [
     { url: "https://api.openai.com/v1", name: "OpenAI" },
     { url: "https://openrouter.com/api/v1", name: "OpenRouter" },
@@ -55,12 +55,12 @@ const { baseURL, apiKey, models } = await openaiConfig({
 });
 
 // Custom Storage - store in sessionStorage.llmProvider
-const { baseURL, apiKey, models } = await openaiConfig({ storage: sessionStorage, key: "llmProvider" });
+const { baseUrl, apiKey, models } = await openaiConfig({ storage: sessionStorage, key: "llmProvider" });
 
-// Custom Babels
-const { baseURL, apiKey, models } = await openaiConfig({
+// Custom Labels
+const { baseUrl, apiKey, models } = await openaiConfig({
   title: "Pick a provider",
-  baseURLLabel: "Your URL",
+  baseUrlLabel: "Your URL",
   apiKeyLabel: "Your Key",
   buttonLabel: "Save",
 });
@@ -78,19 +78,19 @@ async function openaiConfig({
   baseUrls: undefined,                            // array of { url, name } objects
   show: false,                                    // true will force prompt even if config exists
   title: "OpenAI API Configuration",              // modal dialog title
-  baseURLLabel: "API Base URL",                   // base URL label
+  baseUrlLabel: "API Base URL",                   // base URL label
   apiKeyLabel: "API Key",                         // api key label
   buttonLabel: "Save & Test",                     // submit button label
 })
-// Returns: { baseURL, apiKey, models: string[] }
+// Returns: { baseUrl, baseURL, apiKey, models: string[] }
 ```
 
 - If there's no valid config, or `show` is true, it displays a Bootstrap modal with:
   - Base URL input with datalist of `defaultBaseUrls`, or a select of `baseUrls`
   - API key input, may be empty, prefilled from storage if present
   - On submit, it:
-    1. Fetches `${baseURL}/models` using the API key
-    2. On success, save `{ baseURL, apiKey }` to storage under `key`; return `{ baseURL, apiKey, models }`
+    1. Fetches `${baseUrl}/models` using the API key
+    2. On success, save `{ baseUrl, apiKey }` to storage under `key`; return `{ baseUrl, baseURL, apiKey, models }`
     3. On failure, throws an Error
   - `baseUrls` overrides `defaultBaseUrls` if both are provided
 - If config exists, it skips the prompt, fetches models and returns
@@ -111,7 +111,7 @@ npm publish
 
 ## Changelog
 
-- **1.1.0** - 2025-07-25 - optional API key and `baseUrls` select
+- **1.1.0** - 2025-07-25 - optional API key, `baseUrls` select, `baseUrl` renamed (returns `baseURL` for compatibility)
 - **1.0.0** - 2025-07-20 - initial release
 
 ## License

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ const { baseURL, apiKey, models } = await openaiConfig({
     { url: "https://api.openai.com/v1", name: "OpenAI" },
     { url: "https://openrouter.com/api/v1", name: "OpenRouter" },
   ],
+  // baseUrls overrides defaultBaseUrls
 });
 
 // Custom Storage - store in sessionStorage.llmProvider

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ async function openaiConfig({
   apiKeyLabel: "API Key",                         // api key label
   buttonLabel: "Save & Test",                     // submit button label
 })
-// Returns: { baseUrl, baseURL, apiKey, models: string[] }
+// Returns: { baseUrl, apiKey, models: string[] }
 ```
 
 - If there's no valid config, or `show` is true, it displays a Bootstrap modal with:
@@ -90,7 +90,7 @@ async function openaiConfig({
   - API key input, may be empty, prefilled from storage if present
   - On submit, it:
     1. Fetches `${baseUrl}/models` using the API key
-    2. On success, save `{ baseUrl, apiKey }` to storage under `key`; return `{ baseUrl, baseURL, apiKey, models }`
+    2. On success, save `{ baseUrl, apiKey }` to storage under `key`; return `{ baseUrl, apiKey, models }`
     3. On failure, throws an Error
   - `baseUrls` overrides `defaultBaseUrls` if both are provided
 - If config exists, it skips the prompt, fetches models and returns

--- a/bootstrap-llm-provider.html
+++ b/bootstrap-llm-provider.html
@@ -14,6 +14,7 @@
       <button id="customBaseURL" class="m-1 btn btn-success">Custom Base URL</button>
       <button id="customStorage" class="m-1 btn btn-danger">Custom Storage</button>
       <button id="customLabels" class="m-1 btn btn-secondary">Custom Labels</button>
+      <button id="baseUrlsSelect" class="m-1 btn btn-info">Base URL Select</button>
     </div>
 
     <pre id="result" class="p-3 text-bg-dark my-5">Results will appear here</pre>
@@ -54,6 +55,20 @@
         baseURLLabel: "Your URL",
         apiKeyLabel: "Your Key",
         buttonLabel: "Save",
+        show: true
+      });
+    });
+    document.getElementById('baseUrlsSelect').addEventListener('click', async () => {
+      showResult({
+        baseUrls: [{
+            url: 'https://api.openai.com/v1',
+            name: 'OpenAI'
+          },
+          {
+            url: 'https://openrouter.com/api/v1',
+            name: 'OpenRouter'
+          }
+        ],
         show: true
       });
     });

--- a/bootstrap-llm-provider.html
+++ b/bootstrap-llm-provider.html
@@ -69,6 +69,7 @@
             name: 'OpenRouter'
           }
         ],
+        // baseUrls overrides defaultBaseUrls
         show: true
       });
     });

--- a/bootstrap-llm-provider.html
+++ b/bootstrap-llm-provider.html
@@ -52,7 +52,7 @@
         storage: sessionStorage,
         key: 'llmProvider',
         title: "Pick a provider",
-        baseURLLabel: "Your URL",
+        baseUrlLabel: "Your URL",
         apiKeyLabel: "Your Key",
         buttonLabel: "Save",
         show: true

--- a/bootstrap-llm-provider.js
+++ b/bootstrap-llm-provider.js
@@ -9,7 +9,7 @@
  * @param {string[]} [opts.defaultBaseUrls] - Datalist URLs
  * @param {{url: string, name: string}[]} [opts.baseUrls] - Select options
  * @param {boolean} [opts.show] - Force prompt even if config exists
- * @returns {Promise<{baseURL: string, apiKey: string, models: string[]}>}
+ * @returns {Promise<{baseUrl: string, baseURL: string, apiKey: string, models: string[]}>}
  */
 export const openaiConfig = async (options = {}) => {
   // Set defaults
@@ -20,15 +20,15 @@ export const openaiConfig = async (options = {}) => {
     baseUrls: undefined,
     show: false,
     title: "OpenAI API Configuration",
-    baseURLLabel: "API Base URL",
+    baseUrlLabel: "API Base URL",
     apiKeyLabel: "API Key",
     buttonLabel: "Save & Test",
     ...options,
   };
   const saved = parseConfig(options.storage.getItem(options.key));
   if (saved && !options.show) {
-    const models = await fetchModels(saved.baseURL, saved.apiKey);
-    return { ...saved, models };
+    const models = await fetchModels(saved.baseUrl, saved.apiKey);
+    return { ...saved, baseURL: saved.baseUrl, models };
   }
   return await promptConfig(saved, options);
 };
@@ -36,14 +36,19 @@ export const openaiConfig = async (options = {}) => {
 function parseConfig(val) {
   try {
     const c = JSON.parse(val);
-    if (c && typeof c.baseURL === "string" && typeof c.apiKey === "string") return c;
+    if (c && typeof c.baseUrl === "string" && typeof c.apiKey === "string") {
+      return { baseUrl: c.baseUrl, apiKey: c.apiKey };
+    }
+    if (c && typeof c.baseURL === "string" && typeof c.apiKey === "string") {
+      return { baseUrl: c.baseURL, apiKey: c.apiKey };
+    }
   } catch {}
 }
 
-async function fetchModels(baseURL, apiKey) {
-  if (!/^https?:\/\//.test(baseURL)) throw new Error("Invalid URL");
+async function fetchModels(baseUrl, apiKey) {
+  if (!/^https?:\/\//.test(baseUrl)) throw new Error("Invalid URL");
   const headers = apiKey ? { Authorization: `Bearer ${apiKey}` } : {};
-  const r = await fetch(baseURL.replace(/\/$/, "") + "/models", { headers });
+  const r = await fetch(baseUrl.replace(/\/$/, "") + "/models", { headers });
   if (!r.ok) throw new Error("Invalid API key or URL");
   const { data } = await r.json();
   if (!data || !Array.isArray(data)) throw new Error("Invalid response");
@@ -52,20 +57,20 @@ async function fetchModels(baseURL, apiKey) {
 
 function promptConfig(
   saved,
-  { storage, key, defaultBaseUrls, baseUrls, title, baseURLLabel, apiKeyLabel, buttonLabel },
+  { storage, key, defaultBaseUrls, baseUrls, title, baseUrlLabel, apiKeyLabel, buttonLabel },
 ) {
   return new Promise((resolve, reject) => {
     removeModal();
     const id = "llm-provider-modal";
-    const base = saved?.baseURL || baseUrls?.[0]?.url || defaultBaseUrls[0];
+    const base = saved?.baseUrl || baseUrls?.[0]?.url || defaultBaseUrls[0];
     const api = saved?.apiKey || "";
     const datalist = defaultBaseUrls.map((u) => `<option value="${u}">`).join("");
     const selectOpts = (baseUrls || [])
       .map(({ url, name }) => `<option value="${url}" ${url === base ? "selected" : ""}>${name}</option>`)
       .join("");
     const baseInput = baseUrls
-      ? `<select name="baseURL" class="form-select">${selectOpts}</select>`
-      : `<input name="baseURL" type="url" class="form-control" list="llm-provider-dl" placeholder="https://api.openai.com/v1" value="${base}"><datalist id="llm-provider-dl">${datalist}</datalist>`;
+      ? `<select name="baseUrl" class="form-select">${selectOpts}</select>`
+      : `<input name="baseUrl" type="url" class="form-control" list="llm-provider-dl" placeholder="https://api.openai.com/v1" value="${base}"><datalist id="llm-provider-dl">${datalist}</datalist>`;
     document.body.insertAdjacentHTML(
       "beforeend",
       /* html */ `
@@ -78,7 +83,7 @@ function promptConfig(
       </div>
       <div class="modal-body">
         <div class="mb-3">
-          <label class="form-label">${baseURLLabel}</label>
+          <label class="form-label">${baseUrlLabel}</label>
           ${baseInput}
         </div>
         <div class="mb-3">
@@ -116,15 +121,15 @@ function promptConfig(
     form.onsubmit = async (e) => {
       e.preventDefault();
       errorDiv.style.display = "none";
-      const baseURL = form.baseURL.value.trim();
+      const baseUrl = form.baseUrl.value.trim();
       const apiKey = form.apiKey.value.trim();
-      if (!/^https?:\/\//.test(baseURL)) return showError("Enter a valid URL");
+      if (!/^https?:\/\//.test(baseUrl)) return showError("Enter a valid URL");
       form.querySelector("button[type=submit]").disabled = true;
       try {
-        const models = await fetchModels(baseURL, apiKey);
-        storage.setItem(key, JSON.stringify({ baseURL, apiKey }));
+        const models = await fetchModels(baseUrl, apiKey);
+        storage.setItem(key, JSON.stringify({ baseUrl, apiKey }));
         cleanup();
-        resolve({ baseURL, apiKey, models });
+        resolve({ baseUrl, baseURL: baseUrl, apiKey, models });
       } catch (err) {
         showError(err.message);
         form.querySelector("button[type=submit]").disabled = false;

--- a/bootstrap-llm-provider.js
+++ b/bootstrap-llm-provider.js
@@ -72,11 +72,11 @@ function promptConfig(
 <div class="modal fade show" id="${id}" tabindex="-1" style="display:block;background:rgba(0,0,0,.4);z-index:1050;">
   <div class="modal-dialog modal-dialog-centered">
     <form class="modal-content shadow-sm">
-      <div class="modal-header bg-primary text-white">
+      <div class="modal-header">
         <h5 class="modal-title">${title}</h5>
-        <button type="button" class="btn-close btn-close-white" aria-label="Close"></button>
+        <button type="button" class="btn-close" aria-label="Close"></button>
       </div>
-      <div class="modal-body bg-light">
+      <div class="modal-body">
         <div class="mb-3">
           <label class="form-label">${baseURLLabel}</label>
           ${baseInput}
@@ -87,7 +87,7 @@ function promptConfig(
         </div>
         <div class="text-danger small" style="display:none"></div>
       </div>
-      <div class="modal-footer bg-light">
+      <div class="modal-footer">
         <button type="submit" class="btn btn-primary w-100">${buttonLabel}</button>
       </div>
     </form>

--- a/bootstrap-llm-provider.test.js
+++ b/bootstrap-llm-provider.test.js
@@ -21,9 +21,9 @@ describe("bootstrap-llm-provider demo UI", () => {
     window.sessionStorage.clear();
   });
 
-  function fillAndSubmitModal({ baseURL, apiKey }) {
-    const baseField = document.querySelector("[name=baseURL]");
-    baseField.value = baseURL;
+  function fillAndSubmitModal({ baseUrl, apiKey }) {
+    const baseField = document.querySelector("[name=baseUrl]");
+    baseField.value = baseUrl;
     const keyField = document.querySelector("input[name=apiKey]");
     keyField.value = apiKey;
     document.querySelector("form").dispatchEvent(new window.Event("submit", { bubbles: true, cancelable: true }));
@@ -35,18 +35,20 @@ describe("bootstrap-llm-provider demo UI", () => {
     // Modal appears
     expect(document.querySelector("#llm-provider-modal")).toBeTruthy();
     // Invalid URL
-    fillAndSubmitModal({ baseURL: "bad", apiKey: "" });
+    fillAndSubmitModal({ baseUrl: "bad", apiKey: "" });
     expect(document.querySelector(".text-danger").textContent).toMatch(/valid url/i);
     // Valid URL, empty key
-    fillAndSubmitModal({ baseURL: "https://api.openai.com/v1", apiKey: "" });
+    fillAndSubmitModal({ baseUrl: "https://api.openai.com/v1", apiKey: "" });
     await vi.waitFor(() => expect(document.querySelector("#llm-provider-modal")).toBeFalsy());
     expect(window.fetch.mock.calls[0][1].headers).toEqual({});
     expect(window.localStorage.getItem("bootstrapLLMProvider_openaiConfig")).toMatch(/"apiKey":""/);
     // Valid input
     document.querySelector("#alwaysShowModal").click();
-    fillAndSubmitModal({ baseURL: "https://api.openai.com/v1", apiKey: "sk-test" });
+    fillAndSubmitModal({ baseUrl: "https://api.openai.com/v1", apiKey: "sk-test" });
     await vi.waitFor(() => expect(document.querySelector("#llm-provider-modal")).toBeFalsy());
-    expect(document.querySelector("#result").textContent).toMatch(/m1/);
+    const res = JSON.parse(document.querySelector("#result").textContent);
+    expect(res.baseURL).toBe(res.baseUrl);
+    expect(res.models.join()).toMatch(/m1/);
     // Saved to localStorage
     expect(window.localStorage.getItem("bootstrapLLMProvider_openaiConfig")).toMatch(/sk-test/);
   });
@@ -54,7 +56,7 @@ describe("bootstrap-llm-provider demo UI", () => {
   it("basicConfig: skips modal if config exists, fetches models", async () => {
     window.localStorage.setItem(
       "bootstrapLLMProvider_openaiConfig",
-      JSON.stringify({ baseURL: "https://api.openai.com/v1", apiKey: "sk-test" }),
+      JSON.stringify({ baseUrl: "https://api.openai.com/v1", apiKey: "sk-test" }),
     );
     window.fetch = vi.fn(() => Promise.resolve({ ok: true, json: () => ({ data: ["m1", "m2"] }) }));
     document.querySelector("#basicConfig").click();
@@ -70,7 +72,7 @@ describe("bootstrap-llm-provider demo UI", () => {
     window.fetch = vi.fn(() => Promise.resolve({ ok: true, json: () => ({ data: ["m3"] }) }));
     document.querySelector("#alwaysShowModal").click();
     expect(document.querySelector("#llm-provider-modal")).toBeTruthy();
-    fillAndSubmitModal({ baseURL: "https://api.openai.com/v1", apiKey: "sk-new" });
+    fillAndSubmitModal({ baseUrl: "https://api.openai.com/v1", apiKey: "sk-new" });
     await vi.waitFor(() => expect(document.querySelector("#result").textContent).toMatch(/m3/));
     expect(window.localStorage.getItem("bootstrapLLMProvider_openaiConfig")).toMatch(/sk-new/);
   });
@@ -80,24 +82,24 @@ describe("bootstrap-llm-provider demo UI", () => {
     document.querySelector("#customBaseURL").click();
     const datalist = document.querySelector("#llm-provider-dl");
     expect(datalist.innerHTML).toContain("openrouter.ai");
-    fillAndSubmitModal({ baseURL: "https://openrouter.ai/api/v1", apiKey: "sk-x" });
+    fillAndSubmitModal({ baseUrl: "https://openrouter.ai/api/v1", apiKey: "sk-x" });
     await vi.waitFor(() => expect(document.querySelector("#result").textContent).toMatch(/m4/));
   });
 
   it("baseUrlsSelect: renders select instead of input", async () => {
     window.fetch = vi.fn(() => Promise.resolve({ ok: true, json: () => ({ data: ["m7"] }) }));
     document.querySelector("#baseUrlsSelect").click();
-    const select = document.querySelector("select[name=baseURL]");
+    const select = document.querySelector("select[name=baseUrl]");
     expect(select).toBeTruthy();
     expect(select.options.length).toBe(2);
-    fillAndSubmitModal({ baseURL: "https://openrouter.com/api/v1", apiKey: "" });
+    fillAndSubmitModal({ baseUrl: "https://openrouter.com/api/v1", apiKey: "" });
     await vi.waitFor(() => expect(document.querySelector("#result").textContent).toMatch(/m7/));
   });
 
   it("customStorage: uses sessionStorage and custom key", async () => {
     window.fetch = vi.fn(() => Promise.resolve({ ok: true, json: () => ({ data: ["m5"] }) }));
     document.querySelector("#customStorage").click();
-    fillAndSubmitModal({ baseURL: "https://api.openai.com/v1", apiKey: "sk-sess" });
+    fillAndSubmitModal({ baseUrl: "https://api.openai.com/v1", apiKey: "sk-sess" });
     await vi.waitFor(() => expect(window.sessionStorage.getItem("llmProvider")).toMatch(/sk-sess/));
     expect(document.querySelector("#result").textContent).toMatch(/m5/);
   });
@@ -109,7 +111,7 @@ describe("bootstrap-llm-provider demo UI", () => {
     expect(document.querySelector("label.form-label").textContent).toBe("Your URL");
     expect(document.querySelectorAll("label.form-label")[1].textContent).toBe("Your Key");
     expect(document.querySelector("button[type=submit]").textContent).toBe("Save");
-    fillAndSubmitModal({ baseURL: "https://api.openai.com/v1", apiKey: "sk-lbl" });
+    fillAndSubmitModal({ baseUrl: "https://api.openai.com/v1", apiKey: "sk-lbl" });
     await vi.waitFor(() => expect(window.sessionStorage.getItem("llmProvider")).toMatch(/sk-lbl/));
     expect(document.querySelector("#result").textContent).toMatch(/m6/);
   });
@@ -117,7 +119,7 @@ describe("bootstrap-llm-provider demo UI", () => {
   it("shows error on fetch failure", async () => {
     window.fetch = vi.fn(() => Promise.resolve({ ok: false }));
     document.querySelector("#basicConfig").click();
-    fillAndSubmitModal({ baseURL: "https://api.openai.com/v1", apiKey: "bad" });
+    fillAndSubmitModal({ baseUrl: "https://api.openai.com/v1", apiKey: "bad" });
     await vi.waitFor(() => expect(document.querySelector(".text-danger").textContent).toMatch(/invalid/i));
   });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bootstrap-llm-provider",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bootstrap-llm-provider",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "MIT",
       "devDependencies": {
         "happy-dom": "^18.0.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bootstrap-llm-provider",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Let users pick their OpenAI compatible API provider (e.g. OpenRouter, Ollama) via a Bootstrap modal",
   "main": "dist/bootstrap-llm-provider.js",
   "exports": {


### PR DESCRIPTION
## Summary
- allow blank API key and remove validation for it
- add `baseUrls` option to use a select instead of datalist
- document new options and add Change log
- add example demo and tests for blank key and baseUrls select
- bump version to 1.1.0

## Verification
- `npm install`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6882e6753384832cb29a6cccdfaadb3e