### PR TITLE
Add help HTML option

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Let users pick their OpenAI compatible API provider (e.g. OpenRouter, Ollama) vi
 To use locally, install via `npm`:
 
 ```bash
-npm install bootstrap-llm-provider@1.1
+npm install bootstrap-llm-provider@1.2
 ```
 
 ... and add this to your script:
@@ -24,13 +24,13 @@ import { openaiConfig } from "./node_modules/bootstrap-llm-provider/dist/bootstr
 To use via CDN, add this to your script:
 
 ```js
-import { openaiConfig } from "https://cdn.jsdelivr.net/npm/bootstrap-llm-provider@1.1";
+import { openaiConfig } from "https://cdn.jsdelivr.net/npm/bootstrap-llm-provider@1.2";
 ```
 
 ## Quick Start
 
 ```js
-import { openaiConfig } from "https://cdn.jsdelivr.net/npm/bootstrap-llm-provider@1.1";
+import { openaiConfig } from "https://cdn.jsdelivr.net/npm/bootstrap-llm-provider@1.2";
 
 // Basic Config - Opens a model and asks user for provider details
 const { baseUrl, apiKey, models } = await openaiConfig();
@@ -64,6 +64,12 @@ const { baseUrl, apiKey, models } = await openaiConfig({
   apiKeyLabel: "Your Key",
   buttonLabel: "Save",
 });
+
+// Help HTML
+const { baseUrl, apiKey, models } = await openaiConfig({
+  help: '<div class="alert alert-info">Get your key from <a href="/">here</a></div>',
+  show: true,
+});
 ```
 
 [](bootstrap-llm-provider.html ":include")
@@ -77,6 +83,7 @@ async function openaiConfig({
   defaultBaseUrls: ["https://api.openai.com/v1"], // array of URL strings for user to pick from
   baseUrls: undefined,                            // array of { url, name } objects
   show: false,                                    // true will force prompt even if config exists
+  help: "",                                       // HTML rendered at top of modal
   title: "OpenAI API Configuration",              // modal dialog title
   baseUrlLabel: "API Base URL",                   // base URL label
   apiKeyLabel: "API Key",                         // api key label
@@ -88,6 +95,7 @@ async function openaiConfig({
 - If there's no valid config, or `show` is true, it displays a Bootstrap modal with:
   - Base URL input with datalist of `defaultBaseUrls`, or a select of `baseUrls`
   - API key input, may be empty, prefilled from storage if present
+  - `help` HTML inserted at the top if provided
   - On submit, it:
     1. Fetches `${baseUrl}/models` using the API key
     2. On success, save `{ baseUrl, apiKey }` to storage under `key`; return `{ baseUrl, apiKey, models }`
@@ -111,6 +119,7 @@ npm publish
 
 ## Changelog
 
+- **1.2.0** - 2025-07-30 - optional `help` HTML parameter
 - **1.1.0** - 2025-07-25 - optional API key, `baseUrls` select, `baseUrl` renamed (returns `baseURL` for compatibility)
 - **1.0.0** - 2025-07-20 - initial release
 

--- a/bootstrap-llm-provider.html
+++ b/bootstrap-llm-provider.html
@@ -15,12 +15,12 @@
       <button id="customStorage" class="m-1 btn btn-danger">Custom Storage</button>
       <button id="customLabels" class="m-1 btn btn-secondary">Custom Labels</button>
       <button id="baseUrlsSelect" class="m-1 btn btn-info">Base URL Select</button>
+      <button id="helpHtml" class="m-1 btn btn-warning">With Help</button>
     </div>
 
     <pre id="result" class="p-3 text-bg-dark my-5">Results will appear here</pre>
   </div>
 
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.7/dist/js/bootstrap.bundle.min.js"></script>
   <script type="module">
     import {
       openaiConfig
@@ -70,6 +70,12 @@
           }
         ],
         // baseUrls overrides defaultBaseUrls
+        show: true
+      });
+    });
+    document.getElementById('helpHtml').addEventListener('click', async () => {
+      showResult({
+        help: '<div class="alert alert-info">Get your key from <a href="/">here</a></div>',
         show: true
       });
     });

--- a/bootstrap-llm-provider.js
+++ b/bootstrap-llm-provider.js
@@ -9,6 +9,7 @@
  * @param {string[]} [opts.defaultBaseUrls] - Datalist URLs
  * @param {{url: string, name: string}[]} [opts.baseUrls] - Select options
  * @param {boolean} [opts.show] - Force prompt even if config exists
+ * @param {string} [opts.help] - HTML to show at top of modal
  * @returns {Promise<{baseUrl: string, baseURL: string, apiKey: string, models: string[]}>}
  */
 export const openaiConfig = async (options = {}) => {
@@ -23,6 +24,7 @@ export const openaiConfig = async (options = {}) => {
     baseUrlLabel: "API Base URL",
     apiKeyLabel: "API Key",
     buttonLabel: "Save & Test",
+    help: "",
     ...options,
   };
   const saved = parseConfig(options.storage.getItem(options.key));
@@ -57,7 +59,7 @@ async function fetchModels(baseUrl, apiKey) {
 
 function promptConfig(
   saved,
-  { storage, key, defaultBaseUrls, baseUrls, title, baseUrlLabel, apiKeyLabel, buttonLabel },
+  { storage, key, defaultBaseUrls, baseUrls, title, baseUrlLabel, apiKeyLabel, buttonLabel, help },
 ) {
   return new Promise((resolve, reject) => {
     removeModal();
@@ -82,6 +84,7 @@ function promptConfig(
         <button type="button" class="btn-close" aria-label="Close"></button>
       </div>
       <div class="modal-body">
+        ${help || ""}
         <div class="mb-3">
           <label class="form-label">${baseUrlLabel}</label>
           ${baseInput}

--- a/bootstrap-llm-provider.test.js
+++ b/bootstrap-llm-provider.test.js
@@ -96,6 +96,15 @@ describe("bootstrap-llm-provider demo UI", () => {
     await vi.waitFor(() => expect(document.querySelector("#result").textContent).toMatch(/m7/));
   });
 
+  it("helpHtml: inserts unsanitized help HTML", async () => {
+    window.fetch = vi.fn(() => Promise.resolve({ ok: true, json: () => ({ data: ["m8"] }) }));
+    document.querySelector("#helpHtml").click();
+    const html = document.querySelector("#llm-provider-modal .modal-body").innerHTML.trim();
+    expect(html.startsWith('<div class="alert alert-info">')).toBe(true);
+    fillAndSubmitModal({ baseUrl: "https://api.openai.com/v1", apiKey: "" });
+    await vi.waitFor(() => expect(document.querySelector("#result").textContent).toMatch(/m8/));
+  });
+
   it("customStorage: uses sessionStorage and custom key", async () => {
     window.fetch = vi.fn(() => Promise.resolve({ ok: true, json: () => ({ data: ["m5"] }) }));
     document.querySelector("#customStorage").click();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bootstrap-llm-provider",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bootstrap-llm-provider",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "license": "MIT",
       "devDependencies": {
         "happy-dom": "^18.0.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bootstrap-llm-provider",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Let users pick their OpenAI compatible API provider (e.g. OpenRouter, Ollama) via a Bootstrap modal",
   "main": "dist/bootstrap-llm-provider.js",
   "exports": {


### PR DESCRIPTION
## Summary
- let the config modal display unsanitized help HTML
- document the `help` option and update example page and tests
- bump version to 1.2.0

## Testing
- `npx -y prettier@3.5 --print-width=120 '**/*.js' '**/*.md'`
- `npx -y js-beautify@1 '**/*.html' --type html --replace --indent-size 2 --max-preserve-newlines 1 --end-with-newline`
- `uvx ruff --line-length 100 || true`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6886f9335ee4832ca39073b12dc78ca2